### PR TITLE
feat(theme) : Prefer system color scheme on first load

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -16,7 +16,14 @@ function App() {
 
   const [isDarkMode, setIsDarkMode] = useState(() => {
     const saved = localStorage.getItem("darkMode");
-    return saved ? JSON.parse(saved) : false;
+
+    if(saved !== null){  
+      return JSON.parse(saved);
+    }
+
+    //match system preference from window properties
+    return window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches;
+
   });
   const iconsPerPage = 100;
 


### PR DESCRIPTION
### What changed
- The default theme now respects the user's system color theme, i.e. Light or Dark (`prefers-color-scheme`) on first visit.
- If a user has previously selected a theme, the saved preference in `localStorage` continues to take priority.
- The existing theme toggle behavior remains unchanged.

### Why
Currently, the site always defaults to light mode unless the user has manually toggled the theme before.
This change improves the first time user experience by aligning the initial theme with the user's system preference, without affecting existing users.

### How
- On initial load, the app checks for a saved theme in `localStorage` in order to check if user had toggled to a theme earlier.
- If none exists, it falls back to the system color scheme using `window.matchMedia`.
- Once a user toggles the theme, their preference is given priority and overrides the system setting.

### Testing
- Manually tested with system light and dark modes. If the system is in Dark Mode, website loads in dark mode instead of the default light Mode.
- Verified theme toggle persistence across reloads
- Ran `npm run lint` and `npm run build`



