### PR TITLE
fix: Remove broken footer links with placeholder hrefs

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -534,9 +534,6 @@ function App() {
                     </a>
                   </li>
                   <li>
-                    <a href="#">Quick Start</a>
-                  </li>
-                  <li>
                     <a href="https://github.com/ig-imanish/mx-icons">GitHub</a>
                   </li>
                   <li>
@@ -583,12 +580,6 @@ function App() {
                     <a href="https://www.npmjs.com/package/mx-icons">
                       NPM Package
                     </a>
-                  </li>
-                  <li>
-                    <a href="#">Donate</a>
-                  </li>
-                  <li>
-                    <a href="#">Changelog</a>
                   </li>
                 </ul>
               </div>


### PR DESCRIPTION
## Description
Removes broken footer links that were pointing to placeholder "#" URLs and causing page jumps.

## Issue
- Users clicking footer links ("Quick Start", "Donate", "Changelog") experienced page jumps
- Links had no actual destination and served no purpose
- This violates UX best practices

## Changes
- Removed "Quick Start" link from Resources section
- Removed "Donate" link from More section  
- Removed "Changelog" link from More section
- Kept only functional, real links with proper URLs

## Benefits
✅ No more broken links causing confusion
✅ Better user experience with only working navigation
✅ Cleaner, more professional footer
✅ Users won't encounter 404s or unexpected behavior

## Testing
- ✅ Verified all remaining links work
- ✅ Checked footer layout still looks good
- ✅ Tested on mobile view

Closes #29