### PR TITLE
Fix: sync dark mode with system preference changes

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -16,8 +16,9 @@ function App() {
 
   const [isDarkMode, setIsDarkMode] = useState(() => {
     const saved = localStorage.getItem("darkMode");
+    const isManual = localStorage.getItem("darkModeManual") === "true";
 
-    if (saved !== null) {
+    if (saved !== null && isManual) {
       return JSON.parse(saved);
     }
 
@@ -51,7 +52,42 @@ function App() {
     }
   }, [isDarkMode]);
 
-  const toggleDarkMode = () => setIsDarkMode(!isDarkMode);
+  // Listen for system theme preference changes
+  useEffect(() => {
+    if (!window.matchMedia) return;
+
+    const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
+    
+    const handleSystemThemeChange = (e) => {
+      const isManual = localStorage.getItem("darkModeManual") === "true";
+      
+      // Only update if user hasn't manually set a preference
+      if (!isManual) {
+        setIsDarkMode(e.matches);
+      }
+    };
+
+    // Modern browsers
+    if (mediaQuery.addEventListener) {
+      mediaQuery.addEventListener("change", handleSystemThemeChange);
+      return () => {
+        mediaQuery.removeEventListener("change", handleSystemThemeChange);
+      };
+    } 
+    // Fallback for older browsers
+    else if (mediaQuery.addListener) {
+      mediaQuery.addListener(handleSystemThemeChange);
+      return () => {
+        mediaQuery.removeListener(handleSystemThemeChange);
+      };
+    }
+  }, []);
+
+  const toggleDarkMode = () => {
+    setIsDarkMode(!isDarkMode);
+    // Mark as manually set when user toggles
+    localStorage.setItem("darkModeManual", "true");
+  };
 
   // Get all available variants
   const allVariants = useMemo(() => {


### PR DESCRIPTION
Closes #37

## 🌓 What this PR does

This PR improves dark mode behavior by making it react to **system theme changes in real time**, while still respecting the user's manual preference.

### Before
- System dark mode was only detected on first load
- Changing OS theme (Light ↔ Dark) while the app was open had no effect
- App always followed the value stored in `localStorage`

### After
- The app now listens to `prefers-color-scheme` changes via `matchMedia`
- When the OS theme changes, the UI updates instantly
- If the user manually toggles dark mode, their preference is respected and system changes are ignored

---

## 🧠 How it works

- Introduced a distinction between:
  - **System-controlled mode**
  - **User-controlled (manual) mode**
- Added a `matchMedia("(prefers-color-scheme: dark)")` listener
- The app updates automatically when the system theme changes, unless the user has manually overridden the theme

---

## ✅ Why this matters

This brings the dark mode behavior in line with modern UX expectations used by apps like GitHub, Vercel, and Google products — where system theme changes are reflected instantly unless the user chooses otherwise.

---

## 🧪 Testing

- Loaded the app with no saved preference → follows system theme
- Changed OS theme while app was open → UI updates instantly
- Used the toggle → manual preference is respected and persisted
