### PR TITLE
fix(ci): only publish NPM package when src/icons/ files change

### DIFF
--- a/.github/workflows/publish-patch.yml
+++ b/.github/workflows/publish-patch.yml
@@ -4,10 +4,8 @@ on:
   push:
     branches:
       - main
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
-      - '.github/**'
+    paths:
+      - 'src/icons/**'
     
 jobs:
   publish:


### PR DESCRIPTION
 Description:

  ## Problem

  The current `publish-patch.yml` workflow publishes a new NPM version on
  **any** file change (except markdown/docs/workflows). This causes
  unnecessary patch version bumps when only the preview app, configuration
  files, or other non-library code is updated.

  ### Evidence of the Issue:
  - **v1.0.30**: Triggered by `src/App.css` changes (pagination CSS fixes) -
   [commit 948d760]
  - **v1.0.29**: Triggered by `src/App.jsx` changes (UI responsiveness
  updates) - [commit 1d5492b]
  - These should NOT have triggered NPM publishes since the icon library
  itself was unchanged

  ## Solution

  Changed the workflow trigger from `paths-ignore` (exclusion list) to
  `paths` (inclusion list) to **only** trigger when files in the
  `src/icons/` directory are modified.

  ### What Changed:
  ```yaml
  # Before (triggered on everything except ignored paths)
  paths-ignore:
    - '**.md'
    - 'docs/**'
    - '.github/**'

  # After (only triggers on icon files)
  paths:
    - 'src/icons/**'

   Testing

  The logic change is straightforward and reviewable. After merge, can be
  verified by:
  1.  Commit to src/App.jsx or other non-icon files → workflow should NOT
  run
  2.  Commit to src/icons/Icon.jsx or any icon component → workflow SHOULD
   run

  📋 Checklist

  - Clear description of changes provided
  - No visual changes (workflow modification)
  - References issue: Closes #47
  - No tests needed (workflow configuration change)
  - No documentation updates needed (internal CI/CD change)
  - Follows conventional commit format (fix(ci):)

   Related

  Closes #47

  ---
  Note: Not tested in fork environment, but the logic change is
  straightforward and reviewable. Happy to test if needed before merge.