### PR TITLE
fix(pagination): empty row issue in backward pagination

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -443,7 +443,7 @@ function App() {
           </div>
         )}
 
-        <div className="icons-grid">
+        <div className="icons-grid" key={currentPage}>
           {paginatedIcons.map((icon) => (
             <button
               key={icon.slug}


### PR DESCRIPTION
Issue:  
When navigating to the last page with fewer icons, an empty row appears due to grid layout not resetting on back navigation.

Solution: 
Added [key={currentPage}](vscode-file://vscode-app/c:/Users/user/AppData/Local/Programs/Microsoft%20VS%20Code/ce099c1ed2/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to the [icons-grid](vscode-file://vscode-app/c:/Users/user/AppData/Local/Programs/Microsoft%20VS%20Code/ce099c1ed2/resources/app/out/vs/code/electron-browser/workbench/workbench.html) div to force React to remount and recompute the grid layout on each page change, ensuring consistent display.

Impact: 
Eliminates visual inconsistency without affecting pagination logic or performance.


https://github.com/user-attachments/assets/59a38d57-a44f-41da-b775-9e874b9c5d48

