### PR TITLE
Polish icon customization modal UI

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -518,41 +518,81 @@
 /* Modal Styles */
 .modal-overlay {
   position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: rgba(10, 12, 18, 0.7);
+  inset: 0;
+  background: rgba(3, 7, 18, 0.82);
+  backdrop-filter: blur(12px) saturate(125%);
+  -webkit-backdrop-filter: blur(12px) saturate(125%);
   display: flex;
   align-items: center;
   justify-content: center;
   z-index: 999;
-  padding: 1rem;
+  padding: clamp(0.75rem, 2vw, 2rem);
+  overflow-y: auto;
   animation: fadeIn 0.2s;
-  inset: 0;
 }
 
 .modal-card {
+  --modal-surface: #142033;
+  --modal-surface-raised: #18263c;
+  --modal-surface-soft: #203149;
+  --modal-surface-deep: #0e1726;
+  --modal-panel-bg: linear-gradient(
+    180deg,
+    rgba(28, 43, 64, 0.92),
+    rgba(14, 24, 40, 0.96)
+  );
+  --modal-line: rgba(148, 163, 184, 0.24);
+  --modal-line-strong: rgba(148, 163, 184, 0.36);
+  --modal-text: #f8fbff;
+  --modal-muted: #a8b5c8;
+  --modal-accent: #7c6cff;
+  --modal-accent-strong: #9b8cff;
+  --modal-code-green: #83f7b3;
+  --modal-icon-button-size: 2.35rem;
+  --modal-icon-button-radius: 9px;
+
   position: relative;
-  background: var(--modal-bg);
-  border-radius: 12px;
-  padding: 2rem;
-  max-width: 600px;
-  width: 100%;
-  max-height: 90vh;
+  display: flex;
+  flex-direction: column;
+  gap: 1.15rem;
+  background:
+    linear-gradient(180deg, rgba(32, 49, 73, 0.92), rgba(18, 29, 46, 0.98)),
+    var(--modal-surface);
+  border: 1px solid var(--modal-line);
+  border-radius: 18px;
+  padding: clamp(1.125rem, 2.2vw, 1.75rem);
+  max-width: 820px;
+  width: min(100%, 820px);
+  max-height: min(92vh, 860px);
   overflow-y: auto;
-  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1),
-    0 10px 10px -5px rgba(0, 0, 0, 0.04);
+  box-shadow:
+    0 34px 80px rgba(0, 0, 0, 0.48),
+    0 1px 0 rgba(255, 255, 255, 0.08) inset;
   animation: modalEnter 0.18s ease-out;
-  scrollbar-width: none;
-  /* Firefox */
-  -ms-overflow-style: none;
-  /* IE and Edge */
+  scrollbar-width: thin;
+  scrollbar-color: var(--modal-line-strong) transparent;
+}
+
+.modal-card::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  border-radius: inherit;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.08), transparent 26%);
 }
 
 .modal-card::-webkit-scrollbar {
-  display: none;
-  /* Chrome, Safari, Opera */
+  width: 8px;
+}
+
+.modal-card::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.modal-card::-webkit-scrollbar-thumb {
+  background: var(--modal-line-strong);
+  border-radius: 999px;
 }
 
 @keyframes slideUp {
@@ -569,128 +609,222 @@
 
 .modal-close {
   position: absolute;
-  top: 1rem;
-  right: 1rem;
-  width: 2rem;
-  height: 2rem;
+  top: 1.05rem;
+  right: 1.05rem;
+  width: var(--modal-icon-button-size);
+  height: var(--modal-icon-button-size);
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 1.5rem;
-  color: #6b7280;
-  background: transparent;
-  border: none;
-  border-radius: 0.375rem;
+  color: var(--modal-muted);
+  background: var(--modal-panel-bg);
+  border: 1px solid var(--modal-line);
+  border-radius: var(--modal-icon-button-radius);
   cursor: pointer;
-  transition: all 0.15s;
+  padding: 0;
+  overflow: hidden;
+  line-height: 0;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.06),
+    0 12px 24px rgba(0, 0, 0, 0.12);
+  transition:
+    transform 0.15s ease,
+    color 0.15s ease,
+    background 0.15s ease,
+    border-color 0.15s ease;
+}
+
+.modal-close-icon {
+  position: relative;
+  width: 0.84rem;
+  height: 0.84rem;
+  display: block;
+}
+
+.modal-close-icon::before,
+.modal-close-icon::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 100%;
+  height: 1.75px;
+  background: currentColor;
+  border-radius: 999px;
+  transform-origin: center;
+}
+
+.modal-close-icon::before {
+  transform: translate(-50%, -50%) rotate(45deg);
+}
+
+.modal-close-icon::after {
+  transform: translate(-50%, -50%) rotate(-45deg);
 }
 
 .modal-close:hover {
-  background: var(--bg-muted);
-  color: var(--text-color);
+  background: linear-gradient(
+    180deg,
+    rgba(35, 53, 78, 0.98),
+    rgba(18, 30, 49, 0.98)
+  );
+  border-color: var(--modal-line-strong);
+  color: var(--modal-text);
+  transform: translateY(-1px);
+}
+
+.modal-close:focus-visible {
+  outline: 2px solid rgba(124, 108, 255, 0.72);
+  outline-offset: 3px;
+}
+
+.modal-header {
+  min-width: 0;
+  padding: 0.1rem 3.35rem 0.1rem 0;
 }
 
 .modal-title {
-  text-align: center;
-  font-size: 1.5rem;
-  font-weight: 600;
-  color: var(--text-color);
-  margin: 0 0 1.5rem 0;
-  padding-right: 2rem;
+  text-align: left;
+  font-size: 1.6rem;
+  font-weight: 750;
+  line-height: 1.15;
+  letter-spacing: 0;
+  color: var(--modal-text);
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+
+.modal-customizer {
+  display: grid;
+  grid-template-columns: minmax(0, 1.1fr) minmax(250px, 0.9fr);
+  gap: 1.1rem;
+  align-items: stretch;
 }
 
 .modal-preview {
+  position: relative;
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 3rem;
-  background: var(--bg-muted);
-  border: 2px dashed var(--border-color);
-  border-radius: 8px;
-  margin-bottom: 1.5rem;
-  height: 150px;
-  min-height: 150px;
+  min-height: 260px;
+  padding: clamp(2rem, 5vw, 3rem);
+  background: var(--modal-panel-bg);
+  border: 1px solid var(--modal-line);
+  border-radius: 14px;
+  margin: 0;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.05),
+    inset 0 -24px 52px rgba(0, 0, 0, 0.12);
+}
+
+.modal-preview svg {
+  filter: drop-shadow(0 16px 22px rgba(0, 0, 0, 0.26));
 }
 
 .modal-controls {
   display: flex;
   flex-direction: column;
-  gap: 1.25rem;
-  margin-bottom: 1.5rem;
-  padding: 1.5rem;
-  background: var(--bg-muted);
-  border-radius: 8px;
+  justify-content: center;
+  gap: 1.35rem;
+  margin: 0;
+  padding: clamp(1.05rem, 2vw, 1.35rem);
+  background: var(--modal-panel-bg);
+  border: 1px solid var(--modal-line);
+  border-radius: 14px;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.045);
 }
 
 .control-group {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.75rem;
 }
 
 .control-group label {
-  font-size: 0.875rem;
-  font-weight: 500;
-  color: var(--secondary-btn-text);
-  display: block;
+  display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: 1rem;
+  font-size: 0.96rem;
+  font-weight: 700;
+  color: var(--modal-text);
 }
 
 .control-group label strong {
-  color: var(--text-color);
-  font-family: "Courier New", Courier, monospace;
-  font-size: 0.8125rem;
+  color: #dbe7ff;
+  font-family: "Fira Code", "Consolas", "Courier New", monospace;
+  font-size: 0.88rem;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
 }
 
 .control-group input[type="range"] {
   width: 100%;
-  height: 6px;
-  background: #e5e7eb;
-  border-radius: 3px;
+  height: 7px;
+  background:
+    linear-gradient(90deg, rgba(124, 108, 255, 0.85), rgba(99, 102, 241, 0.4)),
+    rgba(226, 232, 240, 0.8);
+  border-radius: 999px;
   outline: none;
   appearance: none;
   -webkit-appearance: none;
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.16);
 }
 
 .control-group input[type="range"]::-webkit-slider-thumb {
   appearance: none;
   -webkit-appearance: none;
-  width: 18px;
-  height: 18px;
-  background: #6366f1;
+  width: 24px;
+  height: 24px;
+  background: var(--modal-accent);
   border-radius: 50%;
+  border: 4px solid var(--modal-surface);
   cursor: pointer;
-  transition: all 0.15s;
+  transition:
+    transform 0.15s ease,
+    background 0.15s ease,
+    box-shadow 0.15s ease;
+  box-shadow:
+    0 0 0 6px rgba(124, 108, 255, 0.14),
+    0 10px 20px rgba(0, 0, 0, 0.24);
 }
 
 .control-group input[type="range"]::-webkit-slider-thumb:hover {
-  background: #4f46e5;
+  background: var(--modal-accent-strong);
   transform: scale(1.1);
 }
 
 .control-group input[type="range"]::-moz-range-thumb {
-  width: 18px;
-  height: 18px;
-  background: #6366f1;
-  border: none;
+  width: 24px;
+  height: 24px;
+  background: var(--modal-accent);
+  border: 4px solid var(--modal-surface);
   border-radius: 50%;
   cursor: pointer;
-  transition: all 0.15s;
+  transition:
+    transform 0.15s ease,
+    background 0.15s ease,
+    box-shadow 0.15s ease;
+  box-shadow:
+    0 0 0 6px rgba(124, 108, 255, 0.14),
+    0 10px 20px rgba(0, 0, 0, 0.24);
 }
 
 .control-group input[type="range"]::-moz-range-thumb:hover {
-  background: #4f46e5;
+  background: var(--modal-accent-strong);
   transform: scale(1.1);
 }
 
 .control-group input[type="color"] {
   width: 100%;
-  height: 40px;
-  border: 1px solid var(--secondary-btn-border);
-  border-radius: 6px;
+  height: 44px;
+  border: 1px solid var(--modal-line-strong);
+  border-radius: 10px;
   cursor: pointer;
-  background: transparent;
+  background: rgba(255, 255, 255, 0.055);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.08),
+    0 10px 24px rgba(0, 0, 0, 0.12);
 }
 
 .control-group input[type="color"]::-webkit-color-swatch-wrapper {
@@ -699,74 +833,97 @@
 
 .control-group input[type="color"]::-webkit-color-swatch {
   border: none;
-  border-radius: 4px;
+  border-radius: 6px;
 }
 
 .modal-code {
   position: relative;
-  background: var(--bg-muted);
-  border: 1px solid var(--border-color);
-  border-radius: 8px;
-  padding: 1.5rem;
+  background: transparent;
+  border: none;
+  border-radius: 0;
+  padding: 0;
 }
 
 .code-copy-btn {
   position: absolute;
-  top: 10px;
-  right: 10px;
+  top: 14px;
+  right: 14px;
 
-  width: 28px;
-  height: 28px;
+  width: var(--modal-icon-button-size);
+  height: var(--modal-icon-button-size);
 
   display: flex;
   align-items: center;
   justify-content: center;
 
-  background: rgba(255, 255, 255, 0.06);
-  border: 1px solid var(--border-color);
-  border-radius: 6px;
+  background: var(--modal-panel-bg);
+  border: 1px solid var(--modal-line);
+  border-radius: var(--modal-icon-button-radius);
 
-  color: var(--text-secondary);
+  color: var(--modal-muted);
   font-size: 13px;
   cursor: pointer;
+  line-height: 0;
 
-  transition: all 0.15s ease;
+  transition:
+    transform 0.15s ease,
+    color 0.15s ease,
+    background 0.15s ease,
+    border-color 0.15s ease;
   z-index: 2;
 }
 
 .code-copy-btn:hover {
-  /* background: rgba(255, 255, 255, 0.12); */
-  color: var(--text-color);
+  background: linear-gradient(
+    180deg,
+    rgba(35, 53, 78, 0.98),
+    rgba(18, 30, 49, 0.98)
+  );
+  border-color: var(--modal-line-strong);
+  color: var(--modal-text);
+  transform: translateY(-1px);
 }
 
-/* .code-copy-btn:active {
+.code-copy-btn:focus-visible {
+  outline: 2px solid rgba(124, 108, 255, 0.72);
+  outline-offset: 3px;
+}
+
+.code-copy-btn:active {
   transform: scale(0.95);
 }
 
-/* Copied state keeps black */
 .code-copy-btn.copied {
-  color: #000000 !important;
+  background: rgba(131, 247, 179, 0.14);
+  border-color: rgba(131, 247, 179, 0.34);
+  color: var(--modal-code-green) !important;
 }
 
-*/ .modal-code h3 {
-  font-size: 1rem;
-  font-weight: 600;
-  color: var(--text-color);
-  margin: 0 0 1rem 0;
+.modal-code h3 {
+  font-size: 1.35rem;
+  font-weight: 800;
+  line-height: 1.2;
+  letter-spacing: 0;
+  color: var(--modal-text);
+  margin: 0 0 0.85rem;
 }
 
 .modal-code pre {
-  margin: 0 0 1rem 0;
-  padding: 38px 14px 14px;
-  background: color-mix(in srgb, var(--modal-bg) 92%, black 8%);
-  border: 1px solid var(--border-color);
-  border-radius: 10px;
-  overflow-x: auto;
+  margin: 0;
+  padding: 50px 20px 20px;
+  background:
+    linear-gradient(180deg, rgba(18, 29, 46, 0.96), rgba(12, 20, 34, 0.98)),
+    var(--modal-surface-deep);
+  border: 1px solid var(--modal-line);
+  border-radius: 14px;
+  overflow: auto;
   position: relative;
   font-family: "JetBrains Mono", "Fira Code", monospace;
-  font-size: 12.5px;
-  line-height: 1.6;
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02);
+  font-size: 0.92rem;
+  line-height: 1.7;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.055),
+    0 18px 34px rgba(0, 0, 0, 0.14);
 }
 
 /* Light mode specific */
@@ -805,9 +962,9 @@
 
 /* code copy button in light mode */
 :root:not(.dark) .code-copy-btn {
-  background: rgba(0, 0, 0, 0.04);
-  border: 1px solid #e5e7eb;
-  color: #6b7280;
+  background: var(--modal-panel-bg);
+  border-color: var(--modal-line);
+  color: var(--modal-muted);
 }
 
 /* Custom Scrollbar for Code Block */
@@ -817,7 +974,7 @@
 }
 
 .modal-code pre::-webkit-scrollbar-track {
-  background: rgba(255, 255, 255, 0.05);
+  background: rgba(255, 255, 255, 0.045);
   backdrop-filter: blur(8px);
   -webkit-backdrop-filter: blur(8px);
   border-radius: 6px;
@@ -825,7 +982,7 @@
 }
 
 .modal-code pre::-webkit-scrollbar-thumb {
-  background: rgba(255, 255, 255, 0.2);
+  background: rgba(148, 163, 184, 0.32);
   backdrop-filter: blur(8px);
   -webkit-backdrop-filter: blur(8px);
   border-radius: 6px;
@@ -835,103 +992,60 @@
 }
 
 .modal-code pre::-webkit-scrollbar-thumb:hover {
-  background: rgba(255, 255, 255, 0.35);
+  background: rgba(148, 163, 184, 0.46);
   backdrop-filter: blur(12px);
   -webkit-backdrop-filter: blur(12px);
 }
 
 .modal-code pre::-webkit-scrollbar-thumb:active {
-  background: rgba(255, 255, 255, 0.45);
+  background: rgba(148, 163, 184, 0.56);
 }
 
 .modal-code code {
   font-family: "Fira Code", "Consolas", "Monaco", "Courier New", monospace;
-  font-size: 0.875rem;
-  color: #d4d4d4;
+  font-size: inherit;
+  color: #dbeafe;
   line-height: 1.7;
-  white-space: pre;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
   display: block;
+  font-variant-numeric: tabular-nums;
 }
 
 /* Syntax Highlighting for Code Block */
 .keyword {
   color: #7dd3fc;
-  font-weight: 500;
+  font-weight: 650;
 }
 
 .component-name {
-  color: #a5b4fc;
-  font-weight: 600;
+  color: #b9c2ff;
+  font-weight: 750;
 }
 
 .prop-name {
-  color: #facc15;
+  color: #fde047;
 }
 
 .prop-value {
-  color: #86efac;
+  color: var(--modal-code-green);
 }
 
 .punctuation {
-  color: #94a3b8;
-}
-
-.copy-button {
-  width: 100%;
-  height: 44px;
-  padding: 0 1.25rem;
-
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 0.5rem;
-
-  font-size: 0.95rem;
-  font-weight: 500;
-  line-height: 1;
-
-  /* always white background as requested */
-  background: #ffffff;
-  border: 1px solid var(--border-color);
-  border-radius: 12px;
-
-  overflow: hidden;
-  cursor: pointer;
-  transition: all 0.2s ease;
-  box-shadow: 0 1px 2px rgba(16, 24, 40, 0.03);
-}
-
-:root.dark .copy-button {
-  background: #1C2636;
-  border-color: rgba(255, 255, 255, 0.06);
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.5);
-}
-
-:root.dark .copy-button span {
-  color: #ffffff !important;
-  text-shadow: none;
-}
-
-:root.dark .copy-button svg {
-  color: #ffffff !important;
-  filter: none;
+  color: #9fb0c8;
 }
 
 :root.dark .code-copy-btn {
-  background: #1C2636;
-  border-color: rgba(255, 255, 255, 0.06);
+  background: var(--modal-panel-bg);
+  border-color: var(--modal-line);
 }
 
 :root:not(.dark) .code-copy-btn.copied {
-  color: #000000 !important;
+  color: #047857 !important;
 }
 
 :root.dark .code-copy-btn.copied {
-  color: #ffffff !important;
-}
-
-:root.dark .copy-button.copied {
-  background: #1C2636;
+  color: var(--modal-code-green) !important;
 }
 
 /* Footer Styles */
@@ -1181,6 +1295,20 @@ a.github-link:hover .github-card:hover {
     padding: 1.25rem 0.75rem;
   }
 
+  .modal-card {
+    width: min(100%, 700px);
+    max-height: calc(100dvh - 1.5rem);
+  }
+
+  .modal-customizer {
+    grid-template-columns: 1fr;
+    gap: 1rem;
+  }
+
+  .modal-preview {
+    min-height: 230px;
+  }
+
   .footer {
     padding: 2.5rem 1.5rem 1.5rem;
   }
@@ -1262,6 +1390,97 @@ a.github-link:hover .github-card:hover {
 
   .icon-name {
     font-size: 0.6875rem;
+  }
+
+  .modal-overlay {
+    align-items: stretch;
+    padding: 0;
+  }
+
+  .modal-card {
+    width: 100%;
+    max-width: none;
+    max-height: 100dvh;
+    min-height: 100dvh;
+    border-radius: 0;
+    border-left: none;
+    border-right: none;
+    padding: 1rem;
+    gap: 0.95rem;
+  }
+
+  .modal-card::before {
+    border-radius: 0;
+  }
+
+  .modal-close {
+    top: 0.9rem;
+    right: 0.9rem;
+    width: var(--modal-icon-button-size);
+    height: var(--modal-icon-button-size);
+  }
+
+  .modal-header {
+    padding-right: 3rem;
+  }
+
+  .modal-title {
+    font-size: 1.2rem;
+    line-height: 1.2;
+  }
+
+  .modal-customizer {
+    gap: 0.85rem;
+  }
+
+  .modal-preview {
+    min-height: clamp(180px, 30dvh, 220px);
+    padding: 1.5rem 1rem;
+    border-radius: 13px;
+  }
+
+  .modal-controls {
+    padding: 1rem;
+    gap: 1.1rem;
+    border-radius: 13px;
+  }
+
+  .control-group {
+    gap: 0.65rem;
+  }
+
+  .control-group label {
+    font-size: 0.92rem;
+  }
+
+  .control-group label strong {
+    font-size: 0.8rem;
+  }
+
+  .control-group input[type="color"] {
+    height: 42px;
+  }
+
+  .modal-code {
+    padding: 0;
+  }
+
+  .modal-code h3 {
+    margin-bottom: 0.75rem;
+  }
+
+  .modal-code pre {
+    padding: 50px 14px 16px;
+    border-radius: 13px;
+    font-size: 0.8rem;
+    line-height: 1.65;
+  }
+
+  .code-copy-btn {
+    top: 12px;
+    right: 12px;
+    width: var(--modal-icon-button-size);
+    height: var(--modal-icon-button-size);
   }
 
   .footer {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -209,12 +209,41 @@ function App() {
   }
 
   async function copyCode(code) {
+    let copied = false;
+
     try {
-      await navigator.clipboard.writeText(code);
+      if (navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(code);
+        copied = true;
+      }
+    } catch (e) {
+      console.error("clipboard api copy failed", e);
+    }
+
+    if (!copied) {
+      const textarea = document.createElement("textarea");
+      textarea.value = code;
+      textarea.setAttribute("readonly", "");
+      textarea.style.position = "fixed";
+      textarea.style.top = "-9999px";
+      textarea.style.opacity = "0";
+      document.body.appendChild(textarea);
+      textarea.select();
+
+      try {
+        copied = document.execCommand("copy");
+      } catch (e) {
+        console.error("fallback copy failed", e);
+      } finally {
+        document.body.removeChild(textarea);
+      }
+    }
+
+    if (copied) {
       setCopiedIcon("code");
       setTimeout(() => setCopiedIcon(null), 1500);
-    } catch (e) {
-      console.error("copy failed", e);
+    } else {
+      console.error("copy failed");
     }
   }
 
@@ -450,6 +479,7 @@ function App() {
               className="icon-card"
               onClick={() => openIconModal(icon)}
               title={`Customize ${icon.componentName}`}
+              aria-label={`Customize ${icon.componentName}`}
             >
               <div className="icon-display">
                 <icon.Component
@@ -488,40 +518,58 @@ function App() {
 
         {selectedIcon && (
           <div className="modal-overlay" onClick={closeIconModal}>
-            <div className="modal-card" onClick={(e) => e.stopPropagation()}>
-              <button className="modal-close" onClick={closeIconModal}>
-                ✕
+            <div
+              className="modal-card"
+              onClick={(e) => e.stopPropagation()}
+              role="dialog"
+              aria-modal="true"
+              aria-labelledby="icon-modal-title"
+            >
+              <button
+                className="modal-close"
+                onClick={closeIconModal}
+                aria-label="Close icon details"
+              >
+                <span className="modal-close-icon" aria-hidden="true" />
               </button>
 
-              <h2 className="modal-title">{selectedIcon.componentName}</h2>
-
-              <div className="modal-preview ">
-                <selectedIcon.Component size={iconSize} color={iconColor} />
+              <div className="modal-header">
+                <h2 id="icon-modal-title" className="modal-title">
+                  {selectedIcon.componentName}
+                </h2>
               </div>
 
-              <div className="modal-controls ">
-                <div className="control-group">
-                  <label>
-                    Size: <strong>{iconSize}px</strong>
-                  </label>
-                  <input
-                    type="range"
-                    min="8"
-                    max="96"
-                    value={iconSize}
-                    onChange={(e) => setIconSize(Number(e.target.value))}
-                  />
+              <div className="modal-customizer">
+                <div className="modal-preview">
+                  <selectedIcon.Component size={iconSize} color={iconColor} />
                 </div>
 
-                <div className="control-group">
-                  <label>
-                    Color: <strong>{iconColor}</strong>
-                  </label>
-                  <input
-                    type="color"
-                    value={iconColor}
-                    onChange={(e) => setIconColor(e.target.value)}
-                  />
+                <div className="modal-controls">
+                  <div className="control-group">
+                    <label htmlFor="icon-size-control">
+                      Size <strong>{iconSize}px</strong>
+                    </label>
+                    <input
+                      id="icon-size-control"
+                      type="range"
+                      min="8"
+                      max="96"
+                      value={iconSize}
+                      onChange={(e) => setIconSize(Number(e.target.value))}
+                    />
+                  </div>
+
+                  <div className="control-group">
+                    <label htmlFor="icon-color-control">
+                      Color <strong>{iconColor}</strong>
+                    </label>
+                    <input
+                      id="icon-color-control"
+                      type="color"
+                      value={iconColor}
+                      onChange={(e) => setIconColor(e.target.value)}
+                    />
+                  </div>
                 </div>
               </div>
 
@@ -530,11 +578,11 @@ function App() {
                 <pre>
                   <button
                     className={`code-copy-btn ${copiedIcon === "code" ? "copied" : ""
-                      }`}
+                    }`}
                     data-tooltip="Copy to clipboard"
                     onClick={() =>
                       copyCode(
-                        `import { ${selectedIcon.componentName} } from 'mx-icons'\n\n<${selectedIcon.componentName} size={${iconSize}} color="${iconColor}" />`
+                        `import {\n  ${selectedIcon.componentName}\n} from 'mx-icons'\n\n<${selectedIcon.componentName}\n  size={${iconSize}}\n  color="${iconColor}"\n/>`
                       )
                     }
                     aria-label="Copy code"
@@ -553,11 +601,13 @@ function App() {
                   </button>
                   <code>
                     <span className="keyword">import</span>
-                    <span className="punctuation"> {"{ "}</span>
+                    <span className="punctuation"> {"{"}</span>
+                    {"\n  "}
                     <span className="component-name">
                       {selectedIcon.componentName}
                     </span>
-                    <span className="punctuation">{" } "}</span>
+                    {"\n"}
+                    <span className="punctuation">{"} "}</span>
                     <span className="keyword">from</span>
                     <span className="prop-value"> 'mx-icons'</span>
                     {"\n\n"}
@@ -578,41 +628,6 @@ function App() {
                     <span className="punctuation">{"/>"}</span>
                   </code>
                 </pre>
-                <button
-                  className={`copy-button ${copiedIcon === "code" ? "copied" : ""
-                    }`}
-                  onClick={() =>
-                    copyCode(
-                      `import { ${selectedIcon.componentName} } from 'mx-icons'\n\n<${selectedIcon.componentName} size={${iconSize}} color="${iconColor}" />`
-                    )
-                  }
-                >
-                  {copiedIcon === "code" ? (
-                    <>
-                      <TickCircleLinear
-                        size={16}
-                        color={isDarkMode ? "#ffffff" : "#000000"}
-                      />
-                      <span
-                        style={{ color: isDarkMode ? "#ffffff" : "#000000" }}
-                      >
-                        Copied!
-                      </span>
-                    </>
-                  ) : (
-                    <>
-                      <CopyLinear
-                        size={16}
-                        color={isDarkMode ? "#ffffff" : "#000000"}
-                      />
-                      <span
-                        style={{ color: isDarkMode ? "#ffffff" : "#000000" }}
-                      >
-                        Copy Code
-                      </span>
-                    </>
-                  )}
-                </button>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- Refined the icon customization modal with improved spacing, dark surface styling, and responsive layout polish.
- Aligned the close and copy icon buttons so they share the same size, radius, background, border, and focus treatment.
- Reduced the color picker height and added a fallback copy path for environments where the Clipboard API is blocked.

## Testing
- npm run lint
- npm run build
- Verified the modal opens/closes and the close/copy button styling matches in a local browser render.