### PR TITLE
fix: added animated icons  #50

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1083,3 +1083,110 @@
         border-top: none;
     }
 }
+
+.icon-display svg {
+    transition: transform 0.25s cubic-bezier(0.34, 1.56, 0.64, 1);
+    transform-origin: center;
+}
+
+.icon-display svg path {
+    transition: transform 0.25s cubic-bezier(0.34, 1.56, 0.64, 1);
+    transform-origin: center;
+}
+
+.icon-card.anim-scale:hover .icon-display svg {
+    transform: scale(1.18);
+}
+
+.icon-card.anim-spin:hover .icon-display svg {
+    animation: mx-spin 1.5s linear infinite;
+}
+
+.icon-card.anim-wiggle:hover .icon-display svg {
+    animation: mx-wiggle 0.5s ease-in-out;
+}
+
+.icon-card.anim-pulse:hover .icon-display svg {
+    animation: mx-pulse 0.6s ease-in-out;
+}
+
+.icon-card.anim-bounce-y:hover .icon-display svg {
+    animation: mx-bounce-y 0.6s ease-in-out;
+}
+
+.icon-card.anim-bounce-x:hover .icon-display svg {
+    animation: mx-bounce-x 0.6s ease-in-out;
+}
+
+.icon-card.anim-copy:hover .icon-display svg path:nth-child(1) {
+    transform: translate(-1.5px, -1.5px);
+}
+
+.icon-card.anim-copy:hover .icon-display svg path:nth-child(2) {
+    transform: translate(1.5px, 1.5px);
+}
+
+.icon-card.anim-trash:hover .icon-display svg path:nth-child(1),
+.icon-card.anim-trash:hover .icon-display svg path:nth-child(2) {
+    transform: translateY(-2px);
+}
+
+@keyframes mx-spin {
+    0% {
+        transform: rotate(0deg);
+    }
+    100% {
+        transform: rotate(360deg);
+    }
+}
+
+@keyframes mx-wiggle {
+    0%, 100% {
+        transform: rotate(0deg);
+    }
+    15% {
+        transform: rotate(-12deg);
+    }
+    30% {
+        transform: rotate(10deg);
+    }
+    45% {
+        transform: rotate(-10deg);
+    }
+    60% {
+        transform: rotate(8deg);
+    }
+    75% {
+        transform: rotate(-4deg);
+    }
+    90% {
+        transform: rotate(2deg);
+    }
+}
+
+@keyframes mx-pulse {
+    0%, 100% {
+        transform: scale(1);
+    }
+    50% {
+        transform: scale(1.18);
+    }
+}
+
+@keyframes mx-bounce-y {
+    0%, 100% {
+        transform: translateY(0);
+    }
+    50% {
+        transform: translateY(-4px);
+    }
+}
+
+@keyframes mx-bounce-x {
+    0%, 100% {
+        transform: translateX(0);
+    }
+    50% {
+        transform: translateX(4px);
+    }
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -80,10 +80,10 @@ function getAnimationClass(slug) {
   ) {
     return "bounce-x";
   }
-  if (s.includes("copy") || s.includes("document") || s.includes("layer")) {
+  if (s.includes("copy") || s.includes("layer")) {
     return "copy";
   }
-  if (s.includes("trash") || s.includes("delete")) {
+  if (s === "trash" || s.startsWith("trash-") || s === "trush-square") {
     return "trash";
   }
   return "scale";

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -21,6 +21,74 @@ import {
   GITHUB_ISSUE_URL,
 } from "./constants";
 
+function getAnimationClass(slug) {
+  if (!slug) return "scale";
+  const s = slug.toLowerCase();
+  if (
+    s.includes("setting") ||
+    s.includes("gear") ||
+    s.includes("refresh") ||
+    s.includes("rotate") ||
+    s.includes("loader") ||
+    s.includes("spinner") ||
+    s.includes("sync") ||
+    s.includes("sun")
+  ) {
+    return "spin";
+  }
+  if (
+    s.includes("bell") ||
+    s.includes("notification") ||
+    s.includes("alert") ||
+    s.includes("alarm") ||
+    s.includes("volume") ||
+    s.includes("music")
+  ) {
+    return "wiggle";
+  }
+  if (
+    s.includes("heart") ||
+    s.includes("like") ||
+    s.includes("love") ||
+    s.includes("favorite") ||
+    s.includes("star") ||
+    s.includes("activity") ||
+    s.includes("chart") ||
+    s.includes("pulse") ||
+    s.includes("health")
+  ) {
+    return "pulse";
+  }
+  if (
+    s.includes("download") ||
+    s.includes("upload") ||
+    s.includes("import") ||
+    s.includes("export") ||
+    s.includes("send") ||
+    s.includes("arrow-down") ||
+    s.includes("arrow-up")
+  ) {
+    return "bounce-y";
+  }
+  if (
+    s.includes("arrow-left") ||
+    s.includes("arrow-right") ||
+    s.includes("next") ||
+    s.includes("back") ||
+    s.includes("forward") ||
+    s.includes("reply")
+  ) {
+    return "bounce-x";
+  }
+  if (s.includes("copy") || s.includes("document") || s.includes("layer")) {
+    return "copy";
+  }
+  if (s.includes("trash") || s.includes("delete")) {
+    return "trash";
+  }
+  return "scale";
+}
+
 function App() {
   const [query, setQuery] = useState("");
   const [debouncedQuery, setDebouncedQuery] = useState("");
@@ -361,7 +429,7 @@ function App() {
               <button
                 key={icon.slug}
                 type="button"
-                className="icon-card"
+                className={`icon-card anim-${getAnimationClass(icon.groupSlug)}`}
                 onClick={() => openIconModal(icon)}
                 title={`Customize ${icon.componentName}`}
                 aria-label={`Customize ${icon.componentName}`}


### PR DESCRIPTION
Fixes #50 

What I have done ...

Dynamic Animation Mapping: Added a local get Animation Class helper in App.jsx to inspect the group Slug of each icon. It assigns a target animation category (e.g. spin, wiggle, pulse, bounce-y, bounce-x, copy, trash, or scale) to the gallery card on hover.

CSS-Only Animations & Transitions: Added keyframes and spring-like transition curves (cubic-bezier(0.34, 1.56, 0.64, 1)) directly inside App.css for smooth, hardware-accelerated micro-interactions.

Targeted SVG Path Animating: Leveraged CSS child path selectors to slide pages apart on copy icons and lift lids on trash icons, matching the behavior of modern animated icon systems.

Zero Dependencies: Avoided importing heavy JavaScript libraries like Framer Motion to preserve the project's fast load times and keep the codebase simple.

https://github.com/user-attachments/assets/b9015033-d658-4bcd-9a03-1b3c39e7b295
